### PR TITLE
Add rotation animation to menu-preview-image-wrapper

### DIFF
--- a/style.css
+++ b/style.css
@@ -279,8 +279,18 @@ body {
   --menu-preview-image-wrapper-size: 8rem;
   width: var(--menu-preview-image-wrapper-size);
   height: var(--menu-preview-image-wrapper-size);
+  animation: rotation 18s linear infinite;
+
 }
 
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+} 
 .menu-preview-image-wrapper img {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
### Summary
Adds a CSS keyframe for infinite 360° rotation with a linear 18s duration.

### Changes
- `@keyframes rotation`: 0deg to 360deg
- `animation: rotation 18s linear infinite;`
